### PR TITLE
CI: Jenkinsfile - mac sdist package testing can retry upto 3 times on failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1411,6 +1411,7 @@ pipeline {
                                                             checkout scm
                                                             unstash 'python sdist'
                                                         },
+                                                        retries: 3,
                                                         testCommand: {
                                                             findFiles(glob: 'dist/*.tar.gz').each{
                                                                 sh(label: 'Running Tox',


### PR DESCRIPTION
ci: mac sdist package testing stage retry upto 3 times on failure