### PR TITLE
ci: dockerfile used by jenkins for tox stages on linux no longer inst…

### DIFF
--- a/ci/docker/linux/tox/apt-packages.txt
+++ b/ci/docker/linux/tox/apt-packages.txt
@@ -1,15 +1,11 @@
 python3-pip
 python3.9-dev
 python3.9-venv
-python3.9-distutils
 python3.10-dev
-python3.10-distutils
 python3.10-venv
 python3.11-dev
-python3.11-distutils
 python3.11-venv
 python3.12-dev
-python3.12-distutils
 python3.12-venv
 python3.13-dev
 python3.13-venv


### PR DESCRIPTION
…alls system python distutils packages